### PR TITLE
Proposed small UI improvement in driver selection panel

### DIFF
--- a/inc/admin/views/option_driver.php
+++ b/inc/admin/views/option_driver.php
@@ -59,7 +59,11 @@ foreach ( array_keys( $option_list ) as $v ) {
 					<td style="width: 80%"><?php echo $v; ?></td>
 					<td style="width: 20%">
 						<?php if ( $driver_status[ $k ] ) : ?>
-							<span class="dashicons dashicons-marker" style="color: #23b900"></span>
+							<?php if ( $option_driver_type == $k ) : ?>
+ 								<span class="dashicons dashicons-yes-alt" style="color: #23b900"></span>
+			 				<?php else : ?>
+ 								<span class="dashicons dashicons-marker" style="color: #23b900"></span>
+ 							<?php endif; ?>
 						<?php else : ?>
 							<span class="dashicons dashicons-marker" style="color: #c60900"></span>
 


### PR DESCRIPTION
I propose a small visual change that I believe improves the UI/UX.

At present, all available methods share the same icon (green circle). My PR changes this behavior by making the selected method use a different icon (green alt check box). This change improves the informational value of this UI element as it allows users to visually assess two things at once: (1) what methods are available and (2) which method has been selected, without having to refer back to the dropdown menu above.

On the example of the `memcached` method:
![cache-master-arrow](https://github.com/terrylinooo/cache-master/assets/6951698/1594d17f-7735-407f-bf3a-06796efb0730)

P.S. Speaking about the UI of this block in general, the dropdown is not strictly necessary. The list below it is a _bona fide_ single-choice selection element. I can look into reworking the whole component so that the the dropdown is ditched entirely, and the `driver-status-box` container becomes clickable like a proper single-choice selector element.

However this requires more work, and I need to make sure my time on this will not be wasted. This PR serves to check if plugin developer @terrylinooo is on board with my thoughts on the subject.